### PR TITLE
Enable browser persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Ingredient-Tracker
-Tracks your household Food Ingrediants and tells you what recipes you can cook from your list based on available ingredients and builds your shopping list
+
+Track household ingredients and get recipe suggestions based on what you have.
+The app stores all data in the browser using **localStorage** so each visitor keeps their own inventory, shopping list and imported recipes.
+
+### Features
+
+- Maintain a list of ingredients with current amounts
+- Generate a shopping list from low stock items
+- Import recipes from URLs (supports "application/ld+json" markup)
+  - Ingredient quantities in US units are automatically converted to UK units
+- Data persists between visits on the same browser
+
+### Development
+
+This project is a simple static site with no build step. Open `index.html` in your browser to run locally or host the files via GitHub Pages.

--- a/app.js
+++ b/app.js
@@ -216,6 +216,30 @@ let appState = {
     currentEditingIngredient: null
 };
 
+const STORAGE_KEY = 'ingredient-tracker-state';
+
+function loadState() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    try {
+        const data = JSON.parse(saved);
+        if (data.ingredients) appState.ingredients = data.ingredients;
+        if (data.shoppingList) appState.shoppingList = data.shoppingList;
+        if (data.recipes) appState.recipes = data.recipes;
+    } catch (err) {
+        console.error('Failed to parse saved state', err);
+    }
+}
+
+function saveState() {
+    const data = {
+        ingredients: appState.ingredients,
+        shoppingList: appState.shoppingList,
+        recipes: appState.recipes
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
 // DOM Elements
 const navToggle = document.getElementById('navToggle');
 const navMenu = document.getElementById('navMenu');
@@ -224,12 +248,14 @@ const pages = document.querySelectorAll('.page');
 
 // Initialize App
 document.addEventListener('DOMContentLoaded', function() {
+    loadState();
     initializeNavigation();
     updateDashboard();
     renderInventory();
     renderRecipes();
     initializeModals();
     initializeShoppingList();
+    initializeRecipeImport();
     initializeSettings();
 });
 
@@ -526,6 +552,7 @@ function saveIngredientUpdate() {
     else ingredient.current_level = 'low';
     
     closeIngredientModal();
+    saveState();
     updateDashboard();
     renderInventory();
     renderRecipes();
@@ -601,6 +628,7 @@ function addMissingIngredientsToShopping() {
     
     closeRecipeModal();
     renderShoppingList();
+    saveState();
 }
 
 // Shopping List Functions
@@ -635,8 +663,9 @@ function generateShoppingListFromLowStock() {
             });
         }
     });
-    
+
     renderShoppingList();
+    saveState();
 }
 
 function addManualItem() {
@@ -651,9 +680,10 @@ function addManualItem() {
         completed: false,
         auto: false
     });
-    
+
     input.value = '';
     renderShoppingList();
+    saveState();
 }
 
 function renderShoppingList() {
@@ -685,17 +715,115 @@ function toggleShoppingItem(id) {
     if (item) {
         item.completed = !item.completed;
         renderShoppingList();
+        saveState();
     }
 }
 
 function removeShoppingItem(id) {
     appState.shoppingList = appState.shoppingList.filter(item => item.id !== id);
     renderShoppingList();
+    saveState();
 }
 
 function clearCompletedItems() {
     appState.shoppingList = appState.shoppingList.filter(item => !item.completed);
     renderShoppingList();
+    saveState();
+}
+
+// Recipe Import Functions
+function initializeRecipeImport() {
+    const importBtn = document.getElementById('importRecipe');
+    const urlInput = document.getElementById('recipeUrl');
+    if (!importBtn || !urlInput) return;
+
+    importBtn.addEventListener('click', () => {
+        const url = urlInput.value.trim();
+        if (!url) return;
+        importRecipeFromUrl(url);
+        urlInput.value = '';
+    });
+}
+
+async function importRecipeFromUrl(url) {
+    try {
+        const response = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+        if (!response.ok) throw new Error('Network response was not ok');
+        const html = await response.text();
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const scripts = Array.from(doc.querySelectorAll('script[type="application/ld+json"]'));
+        let recipeData = null;
+        for (const script of scripts) {
+            try {
+                let data = JSON.parse(script.textContent);
+                if (Array.isArray(data)) data = data.find(d => d['@type'] === 'Recipe');
+                if (data && data['@graph']) data = data['@graph'].find(d => d['@type'] === 'Recipe');
+                if (data && data['@type'] === 'Recipe') {
+                    recipeData = data;
+                    break;
+                }
+            } catch (err) {
+                continue;
+            }
+        }
+
+        if (!recipeData || !recipeData.recipeIngredient) {
+            alert('Unable to parse recipe data from the provided URL.');
+            return;
+        }
+
+        const ingredients = recipeData.recipeIngredient.map(parseIngredientLine);
+
+        const recipe = {
+            id: Date.now(),
+            name: recipeData.name || 'Imported Recipe',
+            prep_time: recipeData.prepTime || '',
+            cook_time: recipeData.cookTime || '',
+            serves: recipeData.recipeYield || '',
+            ingredients
+        };
+
+        appState.recipes.push(recipe);
+        saveState();
+        renderRecipes();
+        alert('Recipe imported successfully!');
+    } catch (err) {
+        console.error(err);
+        alert('Failed to import recipe.');
+    }
+}
+
+function parseIngredientLine(line) {
+    const match = line.match(/^(\d+[\/.]?\d*)?\s*(\w+)?\s*(.*)$/);
+    let amount = parseFloat(match?.[1]) || 1;
+    let unit = match?.[2] ? match[2].toLowerCase() : '';
+    let name = match?.[3] || line;
+
+    const converted = convertUStoUK(amount, unit);
+    return { name: name.trim(), amount: converted.amount, unit: converted.unit };
+}
+
+function convertUStoUK(amount, unit) {
+    const map = {
+        cup: { unit: 'ml', factor: 240 },
+        cups: { unit: 'ml', factor: 240 },
+        oz: { unit: 'g', factor: 28.35 },
+        ounce: { unit: 'g', factor: 28.35 },
+        ounces: { unit: 'g', factor: 28.35 },
+        lb: { unit: 'g', factor: 453.6 },
+        lbs: { unit: 'g', factor: 453.6 },
+        pound: { unit: 'g', factor: 453.6 },
+        pounds: { unit: 'g', factor: 453.6 },
+        pint: { unit: 'ml', factor: 568 },
+        pints: { unit: 'ml', factor: 568 },
+        quart: { unit: 'ml', factor: 946 },
+        quarts: { unit: 'ml', factor: 946 }
+    };
+    const conv = map[unit];
+    if (conv) {
+        return { amount: Math.round(amount * conv.factor), unit: conv.unit };
+    }
+    return { amount, unit };
 }
 
 // Settings Functions
@@ -737,7 +865,8 @@ function addNewIngredient() {
     };
     
     appState.ingredients.push(newIngredient);
-    
+    saveState();
+
     // Clear form
     document.getElementById('newIngredientName').value = '';
     document.getElementById('newIngredientUnit').value = '';

--- a/index.html
+++ b/index.html
@@ -108,7 +108,17 @@
             <div class="container">
                 <h2>Recipe Suggestions</h2>
                 <p class="text-secondary">Check which recipes you can make with your current ingredients</p>
-                
+
+                <div class="card mt-8">
+                    <div class="card__body">
+                        <h3>Import Recipe</h3>
+                        <div class="flex gap-8">
+                            <input type="url" id="recipeUrl" class="form-control" placeholder="Enter recipe URL...">
+                            <button class="btn btn--outline" id="importRecipe">Import</button>
+                        </div>
+                    </div>
+                </div>
+
                 <div id="recipesList" class="recipes-grid">
                     <!-- Populated by JavaScript -->
                 </div>


### PR DESCRIPTION
## Summary
- implement `loadState` and `saveState` helpers
- initialize app by loading stored data and recipe import support
- add recipe import UI and conversion helpers
- persist inventory, shopping list and imported recipes to `localStorage`
- document features and persistence setup in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684b186963fc8322845af6a033c4072d