### PR TITLE
Improve shopping list behavior

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,7 +213,6 @@ let appState = {
         }
     ],
     shoppingList: [],
-    purchases: [],
     currentEditingIngredient: null
 };
 
@@ -225,10 +224,16 @@ function loadState() {
     try {
         const data = JSON.parse(saved);
         if (data.ingredients) appState.ingredients = data.ingredients;
-        if (data.shoppingList) appState.shoppingList = data.shoppingList;
-        if (data.purchases) appState.purchases = data.purchases;
-        else if (data.orders) appState.purchases = data.orders; // backwards compat
+        if (data.shoppingList) {
+            appState.shoppingList = data.shoppingList.map(item => ({
+                ...item,
+                qty: item.qty ?? item.amount ?? 1,
+                selectedUnit: item.selectedUnit ?? item.unit ?? ''
+            }));
+        }
         if (data.recipes) appState.recipes = data.recipes;
+        // ensure new properties persist
+        saveState();
     } catch (err) {
         console.warn('Failed to parse saved state', err);
     }
@@ -238,7 +243,6 @@ function saveState() {
     const data = {
         ingredients: appState.ingredients,
         shoppingList: appState.shoppingList,
-        purchases: appState.purchases,
         recipes: appState.recipes
     };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
@@ -639,13 +643,11 @@ function addMissingIngredientsToShopping() {
 function initializeShoppingList() {
     const generateBtn = document.getElementById('generateShoppingList');
     const clearBtn = document.getElementById('clearCompleted');
-    const receiveBtn = document.getElementById('receiveDelivered');
     const addBtn = document.getElementById('addManualItem');
     const manualInput = document.getElementById('manualItem');
 
     generateBtn.addEventListener('click', generateShoppingListFromLowStock);
     clearBtn.addEventListener('click', clearCompletedItems);
-    receiveBtn.addEventListener('click', receiveDelivered);
     addBtn.addEventListener('click', addManualItem);
     
     manualInput.addEventListener('keypress', (e) => {
@@ -664,6 +666,8 @@ function generateShoppingListFromLowStock() {
                 name: item.name,
                 amount: item.medium - item.current_amount,
                 unit: item.unit,
+                qty: item.medium - item.current_amount,
+                selectedUnit: item.unit,
                 completed: false,
                 auto: true
             });
@@ -683,6 +687,8 @@ function addManualItem() {
     appState.shoppingList.push({
         id: Date.now(),
         name: itemName,
+        qty: 1,
+        selectedUnit: '',
         completed: false,
         auto: false
     });
@@ -702,9 +708,19 @@ async function renderShoppingList() {
     
     let html = '';
     const allUnits = [...new Set(appState.ingredients.map(i => i.unit).filter(Boolean))];
+    let changed = false;
     for (const item of appState.shoppingList) {
         const ingredient = findIngredientByName(item.name);
-        const defaultUnit = item.unit || ingredient?.unit || allUnits[0] || '';
+        if (item.qty == null) {
+            item.qty = item.amount ?? 1;
+            changed = true;
+        }
+        if (!item.selectedUnit) {
+            item.selectedUnit = item.unit || ingredient?.unit || allUnits[0] || '';
+            changed = true;
+        }
+        const defaultUnit = item.selectedUnit;
+        const qty = item.qty;
         html += `
         <div class="shopping-item shopping-list-item ${item.completed ? 'completed' : ''}">
             <input type="checkbox" class="shopping-checkbox" data-item="${item.name}"
@@ -715,25 +731,32 @@ async function renderShoppingList() {
                 ${item.amount ? `<div class="text-secondary">${item.amount} ${item.unit || ''}</div>` : ''}
             </div>
             <button class="shopping-item-remove" onclick="removeShoppingItem(${item.id})">✗</button>
-            <select data-item="${item.name}">
+            <select data-id="${item.id}">
                 ${allUnits.map(u => `<option value="${u}" ${u === defaultUnit ? 'selected' : ''}>${u}</option>`).join('')}
             </select>
-            <input type="number" min="0" step="0.1" value="1" data-qty="${item.name}">
-            <button data-add="${item.name}">Add purchased</button>
+            <input type="number" min="0" step="0.1" value="${qty}" data-qty="${item.id}">
         </div>`;
     }
     shoppingContainer.innerHTML = html;
+    if (changed) saveState();
 
-    // attach purchase handlers
-    shoppingContainer.querySelectorAll('[data-add]').forEach(btn => {
-        btn.addEventListener('click', e => {
-            const item = e.target.dataset.add;
-            const select = e.target.previousElementSibling.previousElementSibling;
-            const qtyInput = e.target.previousElementSibling;
-            const unit = select.value;
-            const qty = parseFloat(qtyInput.value) || 0;
-            if (qty > 0) {
-                appState.purchases.push({ item, unit, qty });
+    shoppingContainer.querySelectorAll('select[data-id]').forEach(sel => {
+        sel.addEventListener('change', e => {
+            const id = parseFloat(sel.dataset.id);
+            const item = appState.shoppingList.find(i => i.id === id);
+            if (item) {
+                item.selectedUnit = sel.value;
+                saveState();
+            }
+        });
+    });
+
+    shoppingContainer.querySelectorAll('input[data-qty]').forEach(inp => {
+        inp.addEventListener('input', e => {
+            const id = parseFloat(inp.dataset.qty);
+            const item = appState.shoppingList.find(i => i.id === id);
+            if (item) {
+                item.qty = parseFloat(inp.value) || 0;
                 saveState();
             }
         });
@@ -744,7 +767,15 @@ function toggleShoppingItem(id) {
     const item = appState.shoppingList.find(item => item.id === id);
     if (item) {
         item.completed = !item.completed;
+        if (item.completed) {
+            const qty = parseFloat(item.qty) || 0;
+            const unit = item.selectedUnit || item.unit;
+            if (qty > 0) {
+                addToInventory(item.name, qty, unit);
+            }
+        }
         renderShoppingList();
+        renderInventory();
         saveState();
     }
 }
@@ -761,36 +792,27 @@ function clearCompletedItems() {
     saveState();
 }
 
-function receiveDelivered() {
-    document.querySelectorAll('.shopping-list-item input[type=checkbox]:checked')
-        .forEach(cb => {
-            const itemName = cb.dataset.item;
-            const purchase = appState.purchases.find(o => o.item === itemName);
-            if (!purchase) return;
-            const ingredient = findIngredientByName(itemName);
-            const qty = purchase.qty;
-            if (ingredient) {
-                ingredient.current_amount = (ingredient.current_amount || 0) + qty;
-                if (ingredient.current_amount >= ingredient.high) ingredient.current_level = 'high';
-                else if (ingredient.current_amount >= ingredient.medium) ingredient.current_level = 'medium';
-                else ingredient.current_level = 'low';
-            } else {
-                appState.ingredients.push({
-                    name: itemName,
-                    category: 'Pantry',
-                    unit: purchase.unit,
-                    low: 1,
-                    medium: 2,
-                    high: 4,
-                    current_level: 'high',
-                    current_amount: qty
-                });
-            }
+function addToInventory(name, qty, unit) {
+    const ingredient = findIngredientByName(name);
+    if (ingredient) {
+        ingredient.current_amount = (ingredient.current_amount || 0) + qty;
+        if (ingredient.current_amount >= ingredient.high) ingredient.current_level = 'high';
+        else if (ingredient.current_amount >= ingredient.medium) ingredient.current_level = 'medium';
+        else ingredient.current_level = 'low';
+    } else {
+        appState.ingredients.push({
+            name,
+            category: 'Pantry',
+            unit,
+            low: 1,
+            medium: 2,
+            high: 4,
+            current_level: 'high',
+            current_amount: qty
         });
-    saveState();
-    renderInventory();
-    renderShoppingList();
+    }
 }
+
 
 // Recipe Import Functions
 function initializeRecipeImport() {
@@ -945,4 +967,3 @@ window.openIngredientModal = openIngredientModal;
 window.openRecipeModal = openRecipeModal;
 window.toggleShoppingItem = toggleShoppingItem;
 window.removeShoppingItem = removeShoppingItem;
-window.receiveDelivered = receiveDelivered;

--- a/index.html
+++ b/index.html
@@ -132,7 +132,6 @@
                 <div class="shopping-actions">
                     <button class="btn btn--primary" id="generateShoppingList">Generate from Low Stock</button>
                     <button class="btn btn--secondary" id="clearCompleted">Clear Completed</button>
-                    <button class="btn" id="receiveDelivered">Receive delivered</button>
                 </div>
 
                 <div class="card mt-8">


### PR DESCRIPTION
## Summary
- simplify the shopping list workflow
- remove 'Receive delivered' button
- store quantity and unit for each shopping item
- auto-add purchased quantity into inventory when checking an item
- persist shopping list data
- fix persistence and checkbox to inventory

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_684eaca604988322951253a387536142